### PR TITLE
Fix for converse set membership

### DIFF
--- a/Euler.swift
+++ b/Euler.swift
@@ -198,7 +198,7 @@ func ∉<T: Equatable> (left: T, right: Array<T>) -> Bool {
 // MARK: Converse Set Membership
 
 infix operator ∋ { associativity left }
-func ∈<T: Equatable> (left: Array<T>, right: T) -> Bool {
+func ∋<T: Equatable> (left: Array<T>, right: T) -> Bool {
     return right ∈ left
 }
 


### PR DESCRIPTION
I think the converse set membership won't work without this change.
